### PR TITLE
Change payment amount in emails

### DIFF
--- a/lib/transaction_service.js
+++ b/lib/transaction_service.js
@@ -182,7 +182,7 @@ TransactionService.prototype.decrypt = function (text) {
 /**
  * Email functionality
  */
-TransactionService.prototype.sendEmail = function (merchantReference, paymentMethod, dataDecodedJson, slug, date, emailSubject, lastFourDigitsOfCard, emailType, pspReference, currency, genericService) {
+TransactionService.prototype.sendEmail = function (value, merchantReference, paymentMethod, dataDecodedJson, slug, date, emailSubject, lastFourDigitsOfCard, emailType, pspReference, currency, genericService) {
 	if (typeof lastFourDigitsOfCard === 'undefined') {
 		lastFourDigitsOfCard = '1234';
 	}
@@ -215,7 +215,7 @@ TransactionService.prototype.sendEmail = function (merchantReference, paymentMet
 					pspReference: pspReference,
 					slug: 'pay-foreign-marriage-certificates',
 					dc: dataDecodedJson.dc,
-					pa: formatMoney(dataDecodedJson.pa),
+					pa: formatMoney(value),
 					paymentMethod: paymentMethod,
 					p: dataDecodedJson.p,
 					registrationsAndCertificates: registrationsAndCertificates(dataDecodedJson),
@@ -231,7 +231,7 @@ TransactionService.prototype.sendEmail = function (merchantReference, paymentMet
 					pspReference: pspReference,
 					slug: 'pay-legalisation-premium-service',
 					dc: dataDecodedJson.dc,
-					pa: formatMoney(dataDecodedJson.pa),
+					pa: formatMoney(value),
 					paymentMethod: paymentMethod,
 					documents: pluralise('documents', documentCount(dataDecodedJson)),
 					lastFourDigits: lastFourDigitsOfCard
@@ -246,7 +246,7 @@ TransactionService.prototype.sendEmail = function (merchantReference, paymentMet
 					pspReference: pspReference,
 					slug: 'pay-legalisation-post',
 					dc: dataDecodedJson.dc,
-					pa: formatMoney(dataDecodedJson.pa),
+					pa: formatMoney(value),
 					paymentMethod: paymentMethod,
 					postage: capitalise(dataDecodedJson.po),
 					documents: pluralise('documents', documentCount(dataDecodedJson)),
@@ -262,7 +262,7 @@ TransactionService.prototype.sendEmail = function (merchantReference, paymentMet
 					pspReference: pspReference,
 					slug: 'pay-register-birth-abroad',
 					dc: dataDecodedJson.dc,
-					pa: formatMoney(dataDecodedJson.pa),
+					pa: formatMoney(value),
 					paymentMethod: paymentMethod,
 					birthRegistrations: pluralise('birth registration', registrationCount(dataDecodedJson)),
 					certificates: pluralise('certificate', documentCount(dataDecodedJson)),
@@ -279,7 +279,7 @@ TransactionService.prototype.sendEmail = function (merchantReference, paymentMet
 					pspReference: pspReference,
 					slug: 'pay-register-death-abroad',
 					dc: dataDecodedJson.dc,
-					pa: formatMoney(dataDecodedJson.pa),
+					pa: formatMoney(value),
 					paymentMethod: paymentMethod,
 					certificates: pluralise('certificate', documentCount(dataDecodedJson)),
 					deathRegistrations: pluralise('death registration', registrationCount(dataDecodedJson)),
@@ -293,7 +293,7 @@ TransactionService.prototype.sendEmail = function (merchantReference, paymentMet
 					merchantReference: merchantReference,
 					pspReference: pspReference,
 					slug: genericService,
-					pa: formatMoney(dataDecodedJson.pa),
+					pa: formatMoney(value),
 					paymentMethod: paymentMethod,
 					lastFourDigits: lastFourDigitsOfCard,
 					currency: currency

--- a/routes/smart_pay.js
+++ b/routes/smart_pay.js
@@ -176,7 +176,7 @@ module.exports = {
 				var collection = db.collection(config.dbCollection);
 				var emailSubject = '';
 				var slug = '';
-				var value = '';
+				var value = body.amount.value / 100;
 				var currency = '';
 				var emailTemplate = '';
 				var emailType = '';
@@ -204,7 +204,6 @@ module.exports = {
 						emailTemplate = 'generic' + '-' + emailType;
 						emailSubject = 'Receipt for ' + slug + ' from the Foreign Office';
 						shopperEmail = body.additionalData.shopperEmail;
-						value = body.amount.value / 100;
 						currency = body.amount.currency;
 						collection = db.collection(config.emailCollection);
 						collection.findOne({
@@ -216,12 +215,12 @@ module.exports = {
 							var fcoOfficeEmailAddress = document.emailAddress;
 							dataDecodedJson = JSON.parse('{"e":"' + fcoOfficeEmailAddress + '","pa":"' + value + '"}');
 							console.log('Sending email to ' + fcoOfficeEmailAddress);
-							transactionService.sendEmail(merchantReference, paymentMethod, dataDecodedJson, emailTemplate, date, emailSubject, lastFourDigitsOfCard, emailType, pspReference, currency, slug);
+							transactionService.sendEmail(value, merchantReference, paymentMethod, dataDecodedJson, emailTemplate, date, emailSubject, lastFourDigitsOfCard, emailType, pspReference, currency, slug);
 						});
 						if (typeof shopperEmail !== 'undefined') {
 							dataDecodedJson = JSON.parse('{"e":"' + shopperEmail + '","pa":"' + value + '"}');
 							console.log('Sending email to customer');
-							transactionService.sendEmail(merchantReference, paymentMethod, dataDecodedJson, emailTemplate, date, emailSubject, lastFourDigitsOfCard, emailType, pspReference, currency, slug);
+							transactionService.sendEmail(value, merchantReference, paymentMethod, dataDecodedJson, emailTemplate, date, emailSubject, lastFourDigitsOfCard, emailType, pspReference, currency, slug);
 						}
 					} else {
 						emailType = 'authorisation';
@@ -255,7 +254,7 @@ module.exports = {
 									dataDecodedJson = JSON.parse(merchantReturnDataDecoded);
 									emailSubject = 'Order for ' + slug + ' from the Foreign Office';
 									console.log('Sending email to customer');
-									transactionService.sendEmail(merchantReference, paymentMethod, dataDecodedJson, emailTemplate, date, emailSubject, lastFourDigitsOfCard, emailType, pspReference);
+									transactionService.sendEmail(value, merchantReference, paymentMethod, dataDecodedJson, emailTemplate, date, emailSubject, lastFourDigitsOfCard, emailType, pspReference);
 								});
 							}
 						});
@@ -294,7 +293,7 @@ module.exports = {
 									dataDecodedJson = JSON.parse(merchantReturnDataDecoded);
 									emailSubject = 'Receipt for ' + slug + ' from the Foreign Office';
 									console.log('Sending email to customer');
-									transactionService.sendEmail(merchantReference, paymentMethod, dataDecodedJson, emailTemplate, date, emailSubject, lastFourDigitsOfCard, emailType, pspReference);
+									transactionService.sendEmail(value, merchantReference, paymentMethod, dataDecodedJson, emailTemplate, date, emailSubject, lastFourDigitsOfCard, emailType, pspReference);
 								});
 							}
 						});
@@ -333,7 +332,7 @@ module.exports = {
 									dataDecodedJson = JSON.parse(merchantReturnDataDecoded);
 									emailSubject = 'Refund for ' + slug + ' from the Foreign Office';
 									console.log('Sending email to customer');
-									transactionService.sendEmail(merchantReference, paymentMethod, dataDecodedJson, emailTemplate, date, emailSubject, lastFourDigitsOfCard, emailType, pspReference);
+									transactionService.sendEmail(value, merchantReference, paymentMethod, dataDecodedJson, emailTemplate, date, emailSubject, lastFourDigitsOfCard, emailType, pspReference);
 								});
 							}
 						});
@@ -372,7 +371,7 @@ module.exports = {
 									dataDecodedJson = JSON.parse(merchantReturnDataDecoded);
 									emailSubject = 'Cancellation for ' + slug + ' from the Foreign Office';
 									console.log('Sending email to customer');
-									transactionService.sendEmail(merchantReference, paymentMethod, dataDecodedJson, emailTemplate, date, emailSubject, lastFourDigitsOfCard, emailType, pspReference);
+									transactionService.sendEmail(value, merchantReference, paymentMethod, dataDecodedJson, emailTemplate, date, emailSubject, lastFourDigitsOfCard, emailType, pspReference);
 								});
 							}
 						});


### PR DESCRIPTION
Change payment amount in emails to come from SmartPay instead of the value saved off in the database. This is to fix a problem where FCO would refund only partial amounts of money for a service. An email would be sent to the customer and it would appear as if the full amount was being refunded.