### PR TITLE
Remove the 'Number of items' phrase from the refund emails

### DIFF
--- a/templates/pay-foreign-marriage-certificates-refund/html.ejs
+++ b/templates/pay-foreign-marriage-certificates-refund/html.ejs
@@ -19,7 +19,6 @@
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Payment Reference: <%= merchantReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">FCO Reference: <%= pspReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Service: <%= slug %></p>
-<p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Number of items: <%= dc %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Amount: &pound;<%= pa %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card type: <%= paymentMethod %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card number: XXXX XXXX XXXX <%= lastFourDigits %></p>

--- a/templates/pay-legalisation-post-refund/html.ejs
+++ b/templates/pay-legalisation-post-refund/html.ejs
@@ -19,7 +19,6 @@
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Payment Reference: <%= merchantReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">FCO Reference: <%= pspReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Service: <%= slug %></p>
-<p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Number of items: <%= dc %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Amount: &pound;<%= pa %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card type: <%= paymentMethod %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card number: XXXX XXXX XXXX <%= lastFourDigits %></p>

--- a/templates/pay-legalisation-premium-service-refund/html.ejs
+++ b/templates/pay-legalisation-premium-service-refund/html.ejs
@@ -19,7 +19,6 @@
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Payment Reference: <%= merchantReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">FCO Reference: <%= pspReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Service: <%= slug %></p>
-<p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Number of items: <%= dc %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Amount: &pound;<%= pa %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card type: <%= paymentMethod %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card number: XXXX XXXX XXXX <%= lastFourDigits %></p>

--- a/templates/pay-register-birth-abroad-refund/html.ejs
+++ b/templates/pay-register-birth-abroad-refund/html.ejs
@@ -19,7 +19,6 @@
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Payment Reference: <%= merchantReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">FCO Reference: <%= pspReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Service: <%= slug %></p>
-<p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Number of items: <%= dc %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Amount: &pound;<%= pa %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card type: <%= paymentMethod %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card number: XXXX XXXX XXXX <%= lastFourDigits %></p>

--- a/templates/pay-register-death-abroad-refund/html.ejs
+++ b/templates/pay-register-death-abroad-refund/html.ejs
@@ -19,7 +19,6 @@
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Payment Reference: <%= merchantReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">FCO Reference: <%= pspReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Service: <%= slug %></p>
-<p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Number of items: <%= dc %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Amount: &pound;<%= pa %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card type: <%= paymentMethod %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card number: XXXX XXXX XXXX <%= lastFourDigits %></p>


### PR DESCRIPTION
Remove the 'Number of items' phrase from the refund emails as the text doesn't make sense when only a partial refund is being made.