### PR TITLE
Fix date being recorded on the payment reference numbers

### DIFF
--- a/lib/transaction_service.js
+++ b/lib/transaction_service.js
@@ -159,12 +159,12 @@ TransactionService.prototype.getDateAndTime = function () {
 	var mm = today.getMonth() + 1;
 	var yyyy = today.getFullYear();
 	if (dd < 10) {
-		dd = '0' + dd;
+		dd = ['0', dd].join('');
 	}
 	if (mm < 10) {
-		mm = '0' + mm;
+		mm = ['0', mm].join('');
 	}
-	today = yyyy + mm + dd;
+	today = [yyyy, mm, dd].join('');
 	return today;
 };
 TransactionService.prototype.encrypt = function (text) {
@@ -214,7 +214,6 @@ TransactionService.prototype.sendEmail = function (value, merchantReference, pay
 					merchantReference: merchantReference,
 					pspReference: pspReference,
 					slug: 'pay-foreign-marriage-certificates',
-					dc: dataDecodedJson.dc,
 					pa: formatMoney(value),
 					paymentMethod: paymentMethod,
 					p: dataDecodedJson.p,
@@ -230,7 +229,6 @@ TransactionService.prototype.sendEmail = function (value, merchantReference, pay
 					merchantReference: merchantReference,
 					pspReference: pspReference,
 					slug: 'pay-legalisation-premium-service',
-					dc: dataDecodedJson.dc,
 					pa: formatMoney(value),
 					paymentMethod: paymentMethod,
 					documents: pluralise('documents', documentCount(dataDecodedJson)),
@@ -245,7 +243,6 @@ TransactionService.prototype.sendEmail = function (value, merchantReference, pay
 					merchantReference: merchantReference,
 					pspReference: pspReference,
 					slug: 'pay-legalisation-post',
-					dc: dataDecodedJson.dc,
 					pa: formatMoney(value),
 					paymentMethod: paymentMethod,
 					postage: capitalise(dataDecodedJson.po),
@@ -261,7 +258,6 @@ TransactionService.prototype.sendEmail = function (value, merchantReference, pay
 					merchantReference: merchantReference,
 					pspReference: pspReference,
 					slug: 'pay-register-birth-abroad',
-					dc: dataDecodedJson.dc,
 					pa: formatMoney(value),
 					paymentMethod: paymentMethod,
 					birthRegistrations: pluralise('birth registration', registrationCount(dataDecodedJson)),
@@ -278,7 +274,6 @@ TransactionService.prototype.sendEmail = function (value, merchantReference, pay
 					merchantReference: merchantReference,
 					pspReference: pspReference,
 					slug: 'pay-register-death-abroad',
-					dc: dataDecodedJson.dc,
 					pa: formatMoney(value),
 					paymentMethod: paymentMethod,
 					certificates: pluralise('certificate', documentCount(dataDecodedJson)),

--- a/routes/smart_pay.js
+++ b/routes/smart_pay.js
@@ -249,7 +249,6 @@ module.exports = {
 								console.log('Nothing returned from database for ' + merchantReference);
 							} else {
 								var decryptedMerchantReturnData = transactionService.decrypt(document.merchantReturnData);
-								lastFourDigitsOfCard = document.binRange;
 								transactionService.inflateAndDecode(decryptedMerchantReturnData, function (merchantReturnDataDecoded) {
 									dataDecodedJson = JSON.parse(merchantReturnDataDecoded);
 									emailSubject = 'Order for ' + slug + ' from the Foreign Office';

--- a/templates/pay-foreign-marriage-certificates-authorisation/html.ejs
+++ b/templates/pay-foreign-marriage-certificates-authorisation/html.ejs
@@ -19,7 +19,6 @@
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Payment Reference: <%= merchantReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">FCO Reference: <%= pspReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Service: <%= slug %></p>
-<p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Number of items: <%= dc %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Amount: &pound;<%= pa %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card type: <%= paymentMethod %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card number: XXXX XXXX XXXX <%= lastFourDigits %></p>

--- a/templates/pay-foreign-marriage-certificates-cancellation/html.ejs
+++ b/templates/pay-foreign-marriage-certificates-cancellation/html.ejs
@@ -19,7 +19,6 @@
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Payment Reference: <%= merchantReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">FCO Reference: <%= pspReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Service: <%= slug %></p>
-<p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Number of items: <%= dc %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Amount: &pound;<%= pa %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card type: <%= paymentMethod %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card number: XXXX XXXX XXXX <%= lastFourDigits %></p>

--- a/templates/pay-foreign-marriage-certificates-capture/html.ejs
+++ b/templates/pay-foreign-marriage-certificates-capture/html.ejs
@@ -19,7 +19,6 @@
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Payment Reference: <%= merchantReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">FCO Reference: <%= pspReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Service: <%= slug %></p>
-<p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Number of items: <%= dc %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Amount: &pound;<%= pa %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card type: <%= paymentMethod %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card number: XXXX XXXX XXXX <%= lastFourDigits %></p>

--- a/templates/pay-legalisation-post-authorisation/html.ejs
+++ b/templates/pay-legalisation-post-authorisation/html.ejs
@@ -19,7 +19,6 @@
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Payment Reference: <%= merchantReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">FCO Reference: <%= pspReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Service: <%= slug %></p>
-<p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Number of items: <%= dc %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Amount: &pound;<%= pa %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card type: <%= paymentMethod %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card number: XXXX XXXX XXXX <%= lastFourDigits %></p>

--- a/templates/pay-legalisation-post-cancellation/html.ejs
+++ b/templates/pay-legalisation-post-cancellation/html.ejs
@@ -19,7 +19,6 @@
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Payment Reference: <%= merchantReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">FCO Reference: <%= pspReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Service: <%= slug %></p>
-<p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Number of items: <%= dc %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Amount: &pound;<%= pa %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card type: <%= paymentMethod %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card number: XXXX XXXX XXXX <%= lastFourDigits %></p>

--- a/templates/pay-legalisation-post-capture/html.ejs
+++ b/templates/pay-legalisation-post-capture/html.ejs
@@ -19,7 +19,6 @@
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Payment Reference: <%= merchantReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">FCO Reference: <%= pspReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Service: <%= slug %></p>
-<p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Number of items: <%= dc %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Amount: &pound;<%= pa %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card type: <%= paymentMethod %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card number: XXXX XXXX XXXX <%= lastFourDigits %></p>

--- a/templates/pay-legalisation-premium-service-authorisation/html.ejs
+++ b/templates/pay-legalisation-premium-service-authorisation/html.ejs
@@ -19,7 +19,6 @@
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Payment Reference: <%= merchantReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">FCO Reference: <%= pspReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Service: <%= slug %></p>
-<p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Number of items: <%= dc %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Amount: &pound;<%= pa %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card type: <%= paymentMethod %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card number: XXXX XXXX XXXX <%= lastFourDigits %></p>

--- a/templates/pay-legalisation-premium-service-cancellation/html.ejs
+++ b/templates/pay-legalisation-premium-service-cancellation/html.ejs
@@ -19,7 +19,6 @@
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Payment Reference: <%= merchantReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">FCO Reference: <%= pspReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Service: <%= slug %></p>
-<p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Number of items: <%= dc %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Amount: &pound;<%= pa %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card type: <%= paymentMethod %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card number: XXXX XXXX XXXX <%= lastFourDigits %></p>

--- a/templates/pay-legalisation-premium-service-capture/html.ejs
+++ b/templates/pay-legalisation-premium-service-capture/html.ejs
@@ -19,7 +19,6 @@
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Payment Reference: <%= merchantReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">FCO Reference: <%= pspReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Service: <%= slug %></p>
-<p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Number of items: <%= dc %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Amount: &pound;<%= pa %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card type: <%= paymentMethod %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card number: XXXX XXXX XXXX <%= lastFourDigits %></p>

--- a/templates/pay-register-birth-abroad-authorisation/html.ejs
+++ b/templates/pay-register-birth-abroad-authorisation/html.ejs
@@ -19,7 +19,6 @@
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Payment Reference: <%= merchantReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">FCO Reference: <%= pspReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Service: <%= slug %></p>
-<p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Number of items: <%= dc %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Amount: &pound;<%= pa %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card type: <%= paymentMethod %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card number: XXXX XXXX XXXX <%= lastFourDigits %></p>

--- a/templates/pay-register-birth-abroad-cancellation/html.ejs
+++ b/templates/pay-register-birth-abroad-cancellation/html.ejs
@@ -19,7 +19,6 @@
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Payment Reference: <%= merchantReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">FCO Reference: <%= pspReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Service: <%= slug %></p>
-<p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Number of items: <%= dc %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Amount: &pound;<%= pa %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card type: <%= paymentMethod %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card number: XXXX XXXX XXXX <%= lastFourDigits %></p>

--- a/templates/pay-register-birth-abroad-capture/html.ejs
+++ b/templates/pay-register-birth-abroad-capture/html.ejs
@@ -19,7 +19,6 @@
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Payment Reference: <%= merchantReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">FCO Reference: <%= pspReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Service: <%= slug %></p>
-<p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Number of items: <%= dc %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Amount: &pound;<%= pa %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card type: <%= paymentMethod %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card number: XXXX XXXX XXXX <%= lastFourDigits %></p>

--- a/templates/pay-register-death-abroad-authorisation/html.ejs
+++ b/templates/pay-register-death-abroad-authorisation/html.ejs
@@ -19,7 +19,6 @@
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Payment Reference: <%= merchantReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">FCO Reference: <%= pspReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Service: <%= slug %></p>
-<p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Number of items: <%= dc %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Amount: &pound;<%= pa %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card type: <%= paymentMethod %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card number: XXXX XXXX XXXX <%= lastFourDigits %></p>

--- a/templates/pay-register-death-abroad-cancellation/html.ejs
+++ b/templates/pay-register-death-abroad-cancellation/html.ejs
@@ -19,7 +19,6 @@
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Payment Reference: <%= merchantReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">FCO Reference: <%= pspReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Service: <%= slug %></p>
-<p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Number of items: <%= dc %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Amount: &pound;<%= pa %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card type: <%= paymentMethod %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card number: XXXX XXXX XXXX <%= lastFourDigits %></p>

--- a/templates/pay-register-death-abroad-capture/html.ejs
+++ b/templates/pay-register-death-abroad-capture/html.ejs
@@ -12,14 +12,13 @@
 
 <h2 style="font-family:nta, Arial, sans-serif;font-size: 1.5em;line-height: 1.04167;font-weight: bold;text-transform: none;">Receipt</h2>
 
-<p style="font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Thank you for your order from the Foreign & Commonwealth Office. We have taken pre-authorisation for the following:</p>
+<p style="font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Thank you for your order from the Foreign & Commonwealth Office. We have now taken payment for the following:</p>
 
 
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Date: <%= date %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Payment Reference: <%= merchantReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">FCO Reference: <%= pspReference %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Service: <%= slug %></p>
-<p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Number of items: <%= dc %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Amount: &pound;<%= pa %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card type: <%= paymentMethod %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card number: XXXX XXXX XXXX <%= lastFourDigits %></p>


### PR DESCRIPTION
AND address issue with last four digits on the authorisation email to get value from smartpay response instead of DB AND remove 'Number of items' text from all emails AND fix wording on Register a death abroad capture emails