### PR TITLE
Add ability to suppress all emails apart from the authorisation emails

### DIFF
--- a/config/smart_pay.js
+++ b/config/smart_pay.js
@@ -17,17 +17,20 @@ exports.config = {
 		'legalisation-post': {
 			pspId: (process.env['smart_pay_legalisation_post_pspid'] || 'pspid'),
 			skinCode: (process.env['smart_pay_legalisation_post_skin_code'] || 'skinCode'),
-			sharedKey: (process.env['smart_pay_legalisation_post_shared_key'] || '00000000000000000000000000000000000000000')
+			sharedKey: (process.env['smart_pay_legalisation_post_shared_key'] || '00000000000000000000000000000000000000000'),
+			sendAllEmails: (process.env['smart_pay_legalisation_post_send_all_emails'] || true)
 		},
 		'legalisation-drop-off': {
 			pspId: (process.env['smart_pay_legalisation_dropoff_pspid'] || 'pspid'),
 			skinCode: (process.env['smart_pay_legalisation_dropoff_skin_code'] || 'skinCode'),
-			sharedKey: (process.env['smart_pay_legalisation_dropoff_shared_key'] || '00000000000000000000000000000000000000000')
+			sharedKey: (process.env['smart_pay_legalisation_dropoff_shared_key'] || '00000000000000000000000000000000000000000'),
+			sendAllEmails: (process.env['smart_pay_legalisation_dropoff_send_all_emails'] || true)
 		},
 		'birth-death-marriage': {
 			pspId: (process.env['smart_pay_birth_pspid'] || 'pspid'),
 			skinCode: (process.env['smart_pay_birth_skin_code'] || 'skinCode'),
-			sharedKey: (process.env['smart_pay_birth_shared_key'] || '00000000000000000000000000000000000000000')
+			sharedKey: (process.env['smart_pay_birth_shared_key'] || '00000000000000000000000000000000000000000'),
+			sendAllEmails: (process.env['smart_pay_birth_send_all_emails'] || true)
 		}
 	}
 };

--- a/routes/smart_pay.js
+++ b/routes/smart_pay.js
@@ -286,14 +286,16 @@ module.exports = {
 							if (document === undefined || document === null) {
 								console.log('Nothing returned from database for ' + merchantReference);
 							} else {
-								var decryptedMerchantReturnData = transactionService.decrypt(document.merchantReturnData);
-								lastFourDigitsOfCard = document.binRange;
-								transactionService.inflateAndDecode(decryptedMerchantReturnData, function (merchantReturnDataDecoded) {
-									dataDecodedJson = JSON.parse(merchantReturnDataDecoded);
-									emailSubject = 'Receipt for ' + slug + ' from the Foreign Office';
-									console.log('Sending email to customer');
-									transactionService.sendEmail(value, merchantReference, paymentMethod, dataDecodedJson, emailTemplate, date, emailSubject, lastFourDigitsOfCard, emailType, pspReference);
-								});
+								if (config.accounts[this.transaction.account].sendAllEmails) {
+									var decryptedMerchantReturnData = transactionService.decrypt(document.merchantReturnData);
+									lastFourDigitsOfCard = document.binRange;
+									transactionService.inflateAndDecode(decryptedMerchantReturnData, function (merchantReturnDataDecoded) {
+										dataDecodedJson = JSON.parse(merchantReturnDataDecoded);
+										emailSubject = 'Receipt for ' + slug + ' from the Foreign Office';
+										console.log('Sending email to customer');
+										transactionService.sendEmail(value, merchantReference, paymentMethod, dataDecodedJson, emailTemplate, date, emailSubject, lastFourDigitsOfCard, emailType, pspReference);
+									});
+								}
 							}
 						});
 					}
@@ -325,14 +327,16 @@ module.exports = {
 							if (document === undefined || document === null) {
 								console.log('Nothing returned from database for ' + merchantReference);
 							} else {
-								var decryptedMerchantReturnData = transactionService.decrypt(document.merchantReturnData);
-								lastFourDigitsOfCard = document.binRange;
-								transactionService.inflateAndDecode(decryptedMerchantReturnData, function (merchantReturnDataDecoded) {
-									dataDecodedJson = JSON.parse(merchantReturnDataDecoded);
-									emailSubject = 'Refund for ' + slug + ' from the Foreign Office';
-									console.log('Sending email to customer');
-									transactionService.sendEmail(value, merchantReference, paymentMethod, dataDecodedJson, emailTemplate, date, emailSubject, lastFourDigitsOfCard, emailType, pspReference);
-								});
+								if (config.accounts[this.transaction.account].sendAllEmails) {
+									var decryptedMerchantReturnData = transactionService.decrypt(document.merchantReturnData);
+									lastFourDigitsOfCard = document.binRange;
+									transactionService.inflateAndDecode(decryptedMerchantReturnData, function (merchantReturnDataDecoded) {
+										dataDecodedJson = JSON.parse(merchantReturnDataDecoded);
+										emailSubject = 'Refund for ' + slug + ' from the Foreign Office';
+										console.log('Sending email to customer');
+										transactionService.sendEmail(value, merchantReference, paymentMethod, dataDecodedJson, emailTemplate, date, emailSubject, lastFourDigitsOfCard, emailType, pspReference);
+									});
+								}
 							}
 						});
 					}
@@ -364,14 +368,16 @@ module.exports = {
 							if (document === undefined || document === null) {
 								console.log('Nothing returned from database for ' + merchantReference);
 							} else {
-								var decryptedMerchantReturnData = transactionService.decrypt(document.merchantReturnData);
-								lastFourDigitsOfCard = document.binRange;
-								transactionService.inflateAndDecode(decryptedMerchantReturnData, function (merchantReturnDataDecoded) {
-									dataDecodedJson = JSON.parse(merchantReturnDataDecoded);
-									emailSubject = 'Cancellation for ' + slug + ' from the Foreign Office';
-									console.log('Sending email to customer');
-									transactionService.sendEmail(value, merchantReference, paymentMethod, dataDecodedJson, emailTemplate, date, emailSubject, lastFourDigitsOfCard, emailType, pspReference);
-								});
+								if (config.accounts[this.transaction.account].sendAllEmails) {
+									var decryptedMerchantReturnData = transactionService.decrypt(document.merchantReturnData);
+									lastFourDigitsOfCard = document.binRange;
+									transactionService.inflateAndDecode(decryptedMerchantReturnData, function (merchantReturnDataDecoded) {
+										dataDecodedJson = JSON.parse(merchantReturnDataDecoded);
+										emailSubject = 'Cancellation for ' + slug + ' from the Foreign Office';
+										console.log('Sending email to customer');
+										transactionService.sendEmail(value, merchantReference, paymentMethod, dataDecodedJson, emailTemplate, date, emailSubject, lastFourDigitsOfCard, emailType, pspReference);
+									});
+								}
 							}
 						});
 					}

--- a/templates/pay-legalisation-post-authorisation/html.ejs
+++ b/templates/pay-legalisation-post-authorisation/html.ejs
@@ -22,12 +22,12 @@
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Amount: &pound;<%= pa %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card type: <%= paymentMethod %></p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Card number: XXXX XXXX XXXX <%= lastFourDigits %></p>
+<% if (postage == 'PREPAID'){ %> 
+<p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">You have paid &pound;<%= pa %> for <%= documents %> without courier delivery</p>
+<% } else { %>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">You have paid &pound;<%= pa %> for <%= documents %> including <%= postage %> postage</p>
-
-
-<p style="font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">When we have confirmed we can provide the service we will take the payment and you will receive a receipt via email.</p>
-
-
+<% } %>
+  
 <h2 style="font-family:nta, Arial, sans-serif;font-size: 1.5em;line-height: 1.04167;font-weight: bold;text-transform: none;">What to do next</h2>
 
 <p style="font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Send the following items to the Legalisation Office:</p>
@@ -49,9 +49,9 @@
 
 <p style="font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">You must post your application and documents - you can't go to the legalisation office in person.</p>
 
-<h2 style="font-family:nta, Arial, sans-serif;font-size: 1.5em;line-height: 1.04167;font-weight: bold;text-transform: none;">If you’re abroad or using a courier</h2>
+<h2 style="font-family:nta, Arial, sans-serif;font-size: 1.5em;line-height: 1.04167;font-weight: bold;text-transform: none;">If you're abroad or using a courier</h2>
   
-<p style="font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Send your application to the following address if you’re abroad or using a courier service in the UK:</p>
+<p style="font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Send your application to the following address if you're abroad or using a courier service in the UK:</p>
   
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">The Legalisation Office</p>
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Foreign &amp; Commonwealth Office</p>

--- a/templates/pay-legalisation-premium-service-authorisation/html.ejs
+++ b/templates/pay-legalisation-premium-service-authorisation/html.ejs
@@ -32,6 +32,8 @@
 
 <p style="font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Bring a print out of this email or payment confirmation page along with the document(s) you wish to legalise.</p>
 
+<p style="font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">From 20 October the Legalisation Office Premium Service will be moving to a new location. If you are a registered business customer, please contact the Legalisation Office for the new address details.</p>
+
 <p style="font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Contact the Legalisation Office if you have any problems.</p>
 
 <p style="text-indent: 25px;font-family:nta, Arial, sans-serif; font-size:1em; line-height:1.31579; font-weight:50 text-transform:none;">Legalisation Office</p>

--- a/views/partials/transactions/pay-legalisation-drop-off/_done.ejs
+++ b/views/partials/transactions/pay-legalisation-drop-off/_done.ejs
@@ -22,6 +22,8 @@
 
 <p>Bring a print out of this payment confirmation page or your emailed confirmation along with the document(s) you wish to legalise.</p>
 
+<p>From 20 October the Legalisation Office Premium Service will be moving to a new location. If you are a registered business customer, please contact the Legalisation Office for the new address details.</p>
+
 <p>Contact the Legalisation Office if you have any problems.</p>
 
 <div class="contact">

--- a/views/partials/transactions/pay-legalisation-post/_done.ejs
+++ b/views/partials/transactions/pay-legalisation-post/_done.ejs
@@ -11,12 +11,15 @@
 		<p>Service: <%= transaction.slug %></p>
 		<p>Amount: &pound;<%= formatMoney(merchantReturnDataJson.pa) %></p>
 		<p>Card type: <%= extractedParameters.paymentMethod %></p>
+		<% if (merchantReturnDataJson.po == "prepaid"){ %>
+		<p>You have paid &pound;<%= formatMoney(merchantReturnDataJson.pa) %> for <%= pluralise("documents", documentCount(merchantReturnDataJson))%> without courier delivery</p>
+		<% } else { -%>
 		<p>You have paid &pound;<%= formatMoney(merchantReturnDataJson.pa) %> for <%= pluralise("documents", documentCount(merchantReturnDataJson))%> including <%= capitalise(merchantReturnDataJson.po) %> postage</p>
+		<% } -%>
 	</div>
 </div>
 
 <p>We have emailed you a confirmation. If you don't receive the email please check your spam folder.</p>
-<p>When we have confirmed we can provide the service we will take the payment and you will receive a receipt via email.</p>
 
 <h2>What to do next</h2>
 
@@ -42,7 +45,7 @@
 <div class="application-notice help-notice"><p>You must post your application and documents - you can't go to the legalisation office in person.</p></div>
 
 
-<h2>If you’re abroad or using a courier</h2>
+<h2>If you're abroad or using a courier</h2>
 
 <p>Send your application to the following address if you’re abroad or using a courier service in the UK:</p>
 


### PR DESCRIPTION
Add ability to suppress all emails apart from the authorisation emails _AND_ update wording for the premium service to notify customers they are moving premises _AND_ update prepaid postage wording on the postal service notifications so they are less misleading