### PR TITLE
Map the transaction account service to each payment

### DIFF
--- a/config/smart_pay.js
+++ b/config/smart_pay.js
@@ -18,19 +18,19 @@ exports.config = {
 			pspId: (process.env['smart_pay_legalisation_post_pspid'] || 'pspid'),
 			skinCode: (process.env['smart_pay_legalisation_post_skin_code'] || 'skinCode'),
 			sharedKey: (process.env['smart_pay_legalisation_post_shared_key'] || '00000000000000000000000000000000000000000'),
-			sendAllEmails: (process.env['smart_pay_legalisation_post_send_all_emails'] || true)
+			sendAllEmails: (process.env['smart_pay_legalisation_post_send_all_emails'] !== 'false')
 		},
 		'legalisation-drop-off': {
 			pspId: (process.env['smart_pay_legalisation_dropoff_pspid'] || 'pspid'),
 			skinCode: (process.env['smart_pay_legalisation_dropoff_skin_code'] || 'skinCode'),
 			sharedKey: (process.env['smart_pay_legalisation_dropoff_shared_key'] || '00000000000000000000000000000000000000000'),
-			sendAllEmails: (process.env['smart_pay_legalisation_dropoff_send_all_emails'] || true)
+			sendAllEmails: (process.env['smart_pay_legalisation_dropoff_send_all_emails'] !== 'false')
 		},
 		'birth-death-marriage': {
 			pspId: (process.env['smart_pay_birth_pspid'] || 'pspid'),
 			skinCode: (process.env['smart_pay_birth_skin_code'] || 'skinCode'),
 			sharedKey: (process.env['smart_pay_birth_shared_key'] || '00000000000000000000000000000000000000000'),
-			sendAllEmails: (process.env['smart_pay_birth_send_all_emails'] || true)
+			sendAllEmails: (process.env['smart_pay_birth_send_all_emails'] !== 'false')
 		}
 	}
 };

--- a/routes/smart_pay.js
+++ b/routes/smart_pay.js
@@ -176,6 +176,7 @@ module.exports = {
 				var collection = db.collection(config.dbCollection);
 				var emailSubject = '';
 				var slug = '';
+				var account = '';
 				var value = body.amount.value / 100;
 				var currency = '';
 				var emailTemplate = '';
@@ -183,14 +184,19 @@ module.exports = {
 				var dataDecodedJson = '';
 				if (transactionSlug[0] === 'PAYFOREIGNMARRIAGECERTIFICATES') {
 					slug = 'pay-foreign-marriage-certificates';
+					account = 'birth-death-marriage';
 				} else if (transactionSlug[0] === 'PAYLEGALISATIONPREMIUMSERVICE') {
 					slug = 'pay-legalisation-premium-service';
+					account = 'legalisation-drop-off';
 				} else if (transactionSlug[0] === 'PAYLEGALISATIONPOST') {
 					slug = 'pay-legalisation-post';
+					account = 'legalisation-post';
 				} else if (transactionSlug[0] === 'PAYREGISTERBIRTHABROAD') {
 					slug = 'pay-register-birth-abroad';
+					account = 'birth-death-marriage';
 				} else if (transactionSlug[0] === 'PAYREGISTERDEATHABROAD') {
 					slug = 'pay-register-death-abroad';
+					account = 'birth-death-marriage';
 				} else {
 					slug = transactionSlug[0];
 				}
@@ -286,7 +292,7 @@ module.exports = {
 							if (document === undefined || document === null) {
 								console.log('Nothing returned from database for ' + merchantReference);
 							} else {
-								if (config.accounts[this.transaction.account].sendAllEmails) {
+								if (config.accounts[account].sendAllEmails) {
 									var decryptedMerchantReturnData = transactionService.decrypt(document.merchantReturnData);
 									lastFourDigitsOfCard = document.binRange;
 									transactionService.inflateAndDecode(decryptedMerchantReturnData, function (merchantReturnDataDecoded) {
@@ -327,7 +333,7 @@ module.exports = {
 							if (document === undefined || document === null) {
 								console.log('Nothing returned from database for ' + merchantReference);
 							} else {
-								if (config.accounts[this.transaction.account].sendAllEmails) {
+								if (config.accounts[account].sendAllEmails) {
 									var decryptedMerchantReturnData = transactionService.decrypt(document.merchantReturnData);
 									lastFourDigitsOfCard = document.binRange;
 									transactionService.inflateAndDecode(decryptedMerchantReturnData, function (merchantReturnDataDecoded) {
@@ -368,7 +374,7 @@ module.exports = {
 							if (document === undefined || document === null) {
 								console.log('Nothing returned from database for ' + merchantReference);
 							} else {
-								if (config.accounts[this.transaction.account].sendAllEmails) {
+								if (config.accounts[account].sendAllEmails) {
 									var decryptedMerchantReturnData = transactionService.decrypt(document.merchantReturnData);
 									lastFourDigitsOfCard = document.binRange;
 									transactionService.inflateAndDecode(decryptedMerchantReturnData, function (merchantReturnDataDecoded) {


### PR DESCRIPTION
Map the transaction account service to each payment returned from Smart Pay. We loose this ability when payments are returned to the notification service. This is to allow the correct 'sendAllEmails' value to be returned from the Smart Pay config.